### PR TITLE
Strip the trailing / from project name.

### DIFF
--- a/autoupdate_app_sources/rest_api.py
+++ b/autoupdate_app_sources/rest_api.py
@@ -63,7 +63,7 @@ class GitlabAPI:
     def __init__(self, upstream: str):
         # Find gitlab api root...
         self.forge_root = self.get_forge_root(upstream).rstrip("/")
-        self.project_path = upstream.replace(self.forge_root, "").lstrip("/")
+        self.project_path = upstream.replace(self.forge_root, "").strip("/")
         self.project_id = self.find_project_id(self.project_path)
 
     def get_forge_root(self, project_url: str) -> str:


### PR DESCRIPTION
Currently updating anarchism fails with

```
Traceback (most recent call last):
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/rest_api.py", line 79, in find_project_id
    project = self.internal_api(f"projects/{project.replace('/', '%2F')}")
  File "/var/www/app_yunohost/apps-tools/autoupdate_app_sources/rest_api.py", line 100, in internal_api
    r.raise_for_status()
  File "/var/www/app_yunohost/apps-tools/venv/lib/python3.9/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://salsa.debian.org/api/v4/projects/debian%2Fanarchism%2F
```

This is because the trailing slash in project name is retained, URL-encoded and passed to server.

Stripping it yields the correct result.