### PR TITLE
Support latest commit on branch

### DIFF
--- a/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/autoupdate_app_sources/autoupdate_app_sources.py
@@ -455,6 +455,7 @@ class AppAutoUpdater:
         upstream = autoupdate.get("upstream", self.main_upstream)
         version_re = autoupdate.get("version_regex", None)
         allow_prereleases = autoupdate.get("allow_prereleases", False)
+        branch_name = autoupdate.get("branch", None)
         _, remote_type, revision_type = strategy.split("_")
 
         api: Union[GithubAPI, GitlabAPI, GiteaForgejoAPI, DownloadPageAPI]
@@ -550,8 +551,12 @@ class AppAutoUpdater:
                 raise ValueError(
                     "For the latest commit strategies, only asset = 'tarball' is supported"
                 )
-            commits = api.commits()
-            latest_commit = commits[0]
+            latest_commit = None
+            if branch_name is None:
+                commits = api.commits()
+                latest_commit = commits[0]
+            else:
+                latest_commit = api.tip_of_branch(branch_name)
             latest_tarball = api.url_for_ref(latest_commit["sha"], RefType.commits)
             # Let's have the version as something like "2023.01.23"
             latest_commit_date = datetime.strptime(

--- a/autoupdate_app_sources/rest_api.py
+++ b/autoupdate_app_sources/rest_api.py
@@ -38,6 +38,10 @@ class GithubAPI:
         """Get a list of commits for project."""
         return self.internal_api(f"repos/{self.upstream_repo}/commits")
 
+    def tip_of_branch(self, branch: str) -> Any:
+        """Get SHA of commit that's tip of provided branch"""
+        return self.internal_api(f"repos/{self.upstream_repo}/branches/{branch}")["commit"]
+
     def releases(self) -> list[dict[str, Any]]:
         """Get a list of releases for project."""
         return self.internal_api(f"repos/{self.upstream_repo}/releases?per_page=100")

--- a/autoupdate_app_sources/rest_api.py
+++ b/autoupdate_app_sources/rest_api.py
@@ -120,6 +120,16 @@ class GitlabAPI:
             )
         ]
 
+    def tip_of_branch(self, branch: str) -> Any:
+        """Get SHA of commit that's tip of provided branch"""
+        commit = self.internal_api(
+            f"projects/{self.project_id}/repository/branches/{branch}"
+        )["commit"]
+        return {
+            "sha": commit["id"],
+            "commit": {"author": {"date": commit["committed_date"]}},
+        }
+
     def releases(self) -> list[dict[str, Any]]:
         """Get a list of releases for project."""
         releases = self.internal_api(f"projects/{self.project_id}/releases")
@@ -195,6 +205,16 @@ class GiteaForgejoAPI:
     def commits(self) -> list[dict[str, Any]]:
         """Get a list of commits for project."""
         return self.internal_api(f"repos/{self.project_path}/commits")
+
+    def tip_of_branch(self, branch: str) -> Any:
+        """Get SHA of commit that's tip of provided branch"""
+        commit = self.internal_api(f"repos/{self.project_path}/branches/{branch}")[
+            "commit"
+        ]
+        return {
+            "sha": commit["id"],
+            "commit": {"author": {"date": commit["timestamp"]}},
+        }
 
     def releases(self) -> list[dict[str, Any]]:
         """Get a list of releases for project."""


### PR DESCRIPTION
Allows `latest_X_commit` from `autoupdate.branch`

```toml
[resources.sources.main]
  url = "https://some.forge.tld/gitea/user/repo/archive/9e013f38eb26fdbe9e63fbaaec079f964d7a8ea1.tar.gz"
  sha256 = "577fce6131d13bc2316629e9f05ef266d83b73d7bf62d1b5adb9200bead0ad5b"
  autoupdate.strategy = "latest_gitea_commit"
  autoupdate.branch = "gh-pages"
```