### PR TITLE
Move readmes to subdir + tag them as generated.

### DIFF
--- a/readme_generator/templates/ALL_README.md.j2
+++ b/readme_generator/templates/ALL_README.md.j2
@@ -1,6 +1,6 @@
 # All available README files by language
 
-- [Read the README in English](README.md)
+- [Read the README in English](../../README.md)
 {% for filename, translated_sentence in links_to_other_READMEs -%}
 - [{{ translated_sentence }}]({{ filename }})
 {% endfor -%}

--- a/readme_generator/templates/README.md.j2
+++ b/readme_generator/templates/README.md.j2
@@ -27,7 +27,7 @@ It shall NOT be edited by hand.") }}
 
 [![{{ _("Install %(application_name)s with YunoHost")|format(application_name=manifest.name) }}](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app={{manifest.id}})
 
-*[{{ _("Read this README in other languages.") }}](./ALL_README.md)*
+*[{{ _("Read this README in other languages.") }}]({{rel_path}}/ALL_README.md)*
 
 > *{{ _("This package allows you to install %(application_name)s quickly and simply on a YunoHost server.")|format(application_name=manifest.name) }}*  
 > *{{ _("If you don't have YunoHost, please consult [the guide](https://yunohost.org/install) to learn how to install it.") }}*

--- a/readme_generator/tests/README.md
+++ b/readme_generator/tests/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 
 [![Install GoToSocial with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
-*[Read this README in other languages.](./ALL_README.md)*
+*[Read this README in other languages.](doc/readme/ALL_README.md)*
 
 > *This package allows you to install GoToSocial quickly and simply on a YunoHost server.*  
 > *If you don't have YunoHost, please consult [the guide](https://yunohost.org/install) to learn how to install it.*


### PR DESCRIPTION
Example changes created (tool run locally + manual change to '.gitattributes' to prove the point), result here: https://github.com/YunoHost-Apps/anarchism_ynh/pull/23/files

Now repo has `README.md` in the root, localized versions + `ALL_README.md` land in `doc/readme` subdir to lower the clutter.

Files are marked as generated hence don't autoexpand in PRs.