### PR TITLE
Add specific upgrade instructions (if any) to PR body

### DIFF
--- a/autoupdate_app_sources/autoupdate_app_sources.py
+++ b/autoupdate_app_sources/autoupdate_app_sources.py
@@ -236,6 +236,10 @@ class AppAutoUpdater:
 
             if msg:
                 commit_msg += f"\n- `{source}` v{version}: {msg}"
+                self.update_instructions = app / "PACKAGE_UPDATE.md"
+                if self.update_instructions.exists():
+                    with open(self.update_instructions) as ui_file:
+                        commit_msg += f"\n\n{ui_file.read()}"
 
             self.repo.manifest_raw = self.replace_version_and_asset_in_manifest(
                 self.repo.manifest_raw,


### PR DESCRIPTION
Upstream upgrade for some apps needs more than just passing CI to get merged (e.g. [jsoncrack_ynh](https://github.com/YunoHost-Apps/jsoncrack_ynh/wiki/How-to-apply-upstream-upgrades-to-this-package))

This PR  aims at implementing what was discussed earlier with @alexAubin, @orhtej2, miro5001 and @lapineige.
- Detailed instructions in Github wiki (to avoid adding translation work in README.md for info which is only relevant to package maintainers). It could be later in YNH doc if several apps share similar detailed instructions (e.g. maybe all apps using NPM, etc.). Here is an example: https://github.com/YunoHost-Apps/jsoncrack_ynh/wiki/How-to-apply-upstream-upgrades-to-this-package
- Short instructions's reminder in the upgrade PR created by the autoupdate script. Those are taken located at the app's root, in the file `PACKAGE_UPDATE.md`  (@AlexAubin, we had talked of calling it `MAINTENANCE.md`, but after a second though it seems to me that since this is meant to be displayed exclusively in autoupdate PR, it may be more fair to have a more specific filename). Here is an example: https://github.com/YunoHost-Apps/jsoncrack_ynh/blob/testing/PACKAGE_UPDATE.md

PR is short & simple but wasn't tested.