### PR TITLE
Fix readme generator hook

### DIFF
--- a/webhooks/webhook.py
+++ b/webhooks/webhook.py
@@ -283,13 +283,12 @@ def reject_wishlist(request: Request, pr_infos: dict, reason=None) -> HTTPRespon
 def generate_and_commit_readmes(repo: Repo) -> bool:
     assert repo.working_tree_dir is not None
     generate_READMEs(Path(repo.working_tree_dir))
-
-    repo.git.add("README*.md")
-    repo.git.add("ALL_README.md")
-
     diff_empty = len(repo.index.diff("HEAD")) == 0
     if diff_empty:
         return False
+
+    for change in repo.index.diff(None):
+        repo.git.add(change.b_path)
 
     repo.index.commit(
         "Auto-update READMEs", author=Actor("yunohost-bot", "yunohost@yunohost.org")


### PR DESCRIPTION
README hook fails because it tries to stage `ALL_README.md` which is now gone with slimmer readmes.

Just stage modified files and pray nothing broke xD