### PR TITLE
Fix READMEs broken by GitHub's styling update

### DIFF
--- a/readme_generator/README.md.j2
+++ b/readme_generator/README.md.j2
@@ -32,8 +32,8 @@ It shall NOT be edited by hand.
 {% endif %}[![Version: {{ manifest.version}}](https://img.shields.io/badge/Version-{{manifest.version|replace("-", "--")}}-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/{{manifest.id}}/)
 
 <div align="center">
-<a href="https://apps.yunohost.org/app/{{manifest.id}}"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
-<a href="https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/issues"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_report_an_issue.svg"/></a>
+<a href="https://apps.yunohost.org/app/{{manifest.id}}"><img width="270px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
+<a href="https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/issues"><img width="270px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_report_an_issue.svg"/></a>
 </div>
 
 ## 📦 Developer info


### PR DESCRIPTION
Two images's styling in all default YNH pacakges' README seems to be broken due to a recent update of GitHub's website, which adds `height:auto;` CSS prop to those images.

Example: https://github.com/YunoHost-Apps/fossflow_ynh
![brokenreadme](https://github.com/user-attachments/assets/19a2d8ed-f699-4b83-ac0e-6517d741a282)

For some reasons I don't get, that is not the case for all repos when the markip, e.g.  https://github.com/YunoHost-Apps/privatebin_ynh

This PR simply hardcodes `width` instead of `height` property for those images, as suggested in https://github.com/orgs/community/discussions/165090