### PR TITLE
readme-generator: Remove upstream line when none exist

### DIFF
--- a/readme_generator/README.md.j2
+++ b/readme_generator/README.md.j2
@@ -40,8 +40,10 @@ It shall NOT be edited by hand.
 
 [![Automatic tests level](https://apps.yunohost.org/badge/cilevel/{{manifest.id}})](https://ci-apps.yunohost.org/ci/apps/{{manifest.id}}/)
 
+{% if manifest.upstream and manifest.upstream.code -%}
 🛠️ Upstream {{manifest.name}} repository: <{{manifest.upstream.code}}>
 
+{% endif -%}
 Pull request are welcome and should target the [`testing` branch](https://github.com/YunoHost-Apps/{{manifest.id}}_ynh/tree/testing).
 
 The `testing` branch can be tested using:


### PR DESCRIPTION
## Context

A Yunohost package may not have an upstream project. That's for example the case of this repo: https://github.com/YunoHost-Apps/my_webapp_ynh

As you can see in the README page, this line can be a bit confusing:
> 🛠️ Upstream My Webapp repository: <>

## Proposed solution

Simply don't generate this line if the upstream section or the upstream code do not exist.