### PR TITLE
[a11y] Improve contrast ratio for background

### DIFF
--- a/readme_generator/README.md.j2
+++ b/readme_generator/README.md.j2
@@ -29,7 +29,7 @@ It shall NOT be edited by hand.
 
 {% if manifest.upstream.website %}[![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)]({{manifest.upstream.website}})
 {% endif %}{% if manifest.upstream.demo %}[![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)]({{manifest.upstream.demo}})
-{% endif %}[![Version: {{ manifest.version}}](https://img.shields.io/badge/Version-{{manifest.version|replace("-", "--")}}-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/{{manifest.id}}/)
+{% endif %}[![Version: {{ manifest.version}}](https://img.shields.io/badge/Version-{{manifest.version|replace("-", "--")}}-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/{{manifest.id}}/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/{{manifest.id}}"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>


### PR DESCRIPTION
See this issue: https://github.com/YunoHost/issues/issues/2614 (here this is a slight improvement)

## Old badge

![old badge sample](https://img.shields.io/badge/Version-3.4.2~ynh1-rgba(0,150,0,1)?style=for-the-badge)

## New badge

![new badge sample](https://img.shields.io/badge/Version-3.4.2~ynh1-rgb(18,138,11)?style=for-the-badge)