### PR TITLE
`*drupal` are clashing with `drupal7` counterparts in the graveyard

### DIFF
--- a/catalog_linter.py
+++ b/catalog_linter.py
@@ -58,7 +58,7 @@ def check_app(
     if wishlist_matches:
         yield f"app seems to be listed in wishlist: {wishlist_matches}", True
 
-    ignored_graveyard_entries = ["mailman", "invoiceninja"]
+    ignored_graveyard_entries = ["mailman", "invoiceninja", "civicrm_drupal", "drupal"]
     graveyard_matches = [
         grave
         for grave in get_graveyard()

--- a/catalog_linter.py
+++ b/catalog_linter.py
@@ -58,6 +58,9 @@ def check_app(
     if wishlist_matches:
         yield f"app seems to be listed in wishlist: {wishlist_matches}", True
 
+    # validate that the app is not (anymore?) in the wishlist
+    # we use fuzzy matching because the id in catalog may not be the same exact id as in the wishlist
+    # some entries are ignore-hard-coded, because e.g. radarr an readarr are really different apps...
     ignored_graveyard_entries = ["mailman", "invoiceninja", "civicrm_drupal", "drupal"]
     graveyard_matches = [
         grave


### PR DESCRIPTION
```
civicrm_drupal:
  - error: app seems to be listed in graveyard: ['civicrm_drupal7']
drupal:
  - error: app seems to be listed in graveyard: ['drupal7']
```